### PR TITLE
Use authenticate endpoint

### DIFF
--- a/client.js
+++ b/client.js
@@ -20,10 +20,8 @@ Client.SANDBOX_BASE = "https://sandbox-connect.rjmetrics.com/v2";
 Client.MAX_REQUEST_SIZE = 100;
 
 Client.prototype.authenticate = function() {
-	return this.pushData(
-		"test",
-		{"keys":["id"], "id": 1},
-		Client.SANDBOX_BASE
+	return this.makeAuthenticateCall(
+		Client.API_BASE
 	);
 }
 
@@ -85,5 +83,30 @@ Client.prototype.makeApiCall = function(tableName, data, baseUrl) {
 
 	return deferred.promise;
 }
+
+Client.prototype.makeAuthenticateCall = function(baseUrl) {
+	if(baseUrl === undefined)
+		baseUrl = Client.API_BASE;
+
+	var fullUrl = baseUrl + "/client/" + this.clientId +
+		"/authenticate?apikey=" + this.apiKey;
+
+	var deferred = Q.defer();
+
+	needle.get(
+		fullUrl,
+		function(error, response, body) {
+			if(error)
+				deferred.reject(error);
+			else
+				deferred.resolve({
+					code: response.statusCode
+				});
+		}
+	)
+
+	return deferred.promise;
+}
+
 
 exports.Client = Client;

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "rjmetrics-examples",
+  "name": "rjmetrics-examples",
   "version": "1.0.0",
   "dependencies": {
-    "rjmetrics": "0.1.1"
+    "rjmetrics": "0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rjmetrics",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"author": "Connor McArthur <cmcarthur@rjmetrics.com>",
 	"description": "RJMetrics Client Library for Javascript",
 	"main": "client.js",


### PR DESCRIPTION
### Motivation
We added the authenticate endpoint to the IAPI, let's use it.   That way the sandbox machine will no longer be production critical.

### API changes
None

### Implementation Notes
The endpoint is called authenticate.  Meaning the apikey provided exists, and matches the client-id in the url.  Implicitly, a 200 response means the apikey has at least REGULAR permissions, meaning the key can push data.  That's an authorization concern, but still a good question to answer.  

### Functional Tests
Ran the example code.
```
➜  node-test  node orders-table.js
Synced order with id 1
Synced order with id 2
Synced order with id 3
Synced order with id 4
Synced order with id 5
```

### Regression Tests

### Screenshots